### PR TITLE
fix(Conventions/Prettier): Use correct tab property

### DIFF
--- a/packages/conventions/prettier.config.js
+++ b/packages/conventions/prettier.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	plugins: [require('prettier-plugin-tailwindcss')],
 	trailingComma: 'es5',
-	tabs: true,
+	useTabs: true,
 	tabWidth: 4,
 	singleQuote: true,
 	printWidth: 80,


### PR DESCRIPTION
The prettier config used a non-existing property "tabs" which I replaced for "useTabs".